### PR TITLE
add config options and respect RavenConfig

### DIFF
--- a/component.json
+++ b/component.json
@@ -7,7 +7,9 @@
   "main": "lib/index.js",
   "dependencies": {
     "segmentio/analytics.js-integration": "^1.0.1",
-    "ianstormtaylor/is": "0.1.0"
+    "ianstormtaylor/is": "0.1.0",
+    "ndhoule/defaults": "1.1.1",
+    "ndhoule/foldl": "1.0.3"
   },
   "development": {
     "segmentio/analytics.js-core": "^2.10.0",

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,8 @@
  */
 
 var integration = require('analytics.js-integration');
+var defaults = require('defaults');
+var foldl = require('foldl');
 var is = require('is');
 
 /**
@@ -26,8 +28,33 @@ var Sentry = module.exports = integration('Sentry')
  */
 
 Sentry.prototype.initialize = function() {
+  var includePaths = this.options.includePaths;
+  var ignoreErrors = this.options.ignoreErrors;
+  var ignoreUrls = this.options.ignoreUrls;
+  var maxMessageLength = this.options.maxMessageLength;
+  var logger = this.options.logger;
+
   var dsn = this.options.config;
-  window.RavenConfig = { dsn: dsn };
+  var config = {};
+
+  if (includePaths.length) config.includePaths = stringsToRegExps(includePaths);
+  if (ignoreErrors.length) config.ignoreErrors = stringsToRegExps(ignoreErrors);
+  if (ignoreUrls.length) config.ignoreUrls = stringsToRegExps(ignoreUrls);
+  if (maxMessageLength) config.maxMessageLength = maxMessageLength;
+  if (logger) config.logger = logger;
+
+  function stringsToRegExps(arr) {
+    return foldl(function(result, val) {
+      result.push(new RegExp(val));
+      return result;
+    }, [], arr);
+  }
+
+  window.RavenConfig = defaults.deep(window.RavenConfig || {}, {
+    config: config,
+    dsn: dsn
+  });
+
   this.load(this.ready);
 };
 


### PR DESCRIPTION
This PR adds support for a few new settings via the UI:

http://raven-js.readthedocs.org/en/latest/config/index.html

Here's the way `window.RavenConfig` is used in initializing the lib — https://github.com/getsentry/raven-js/blob/master/src/raven.js#L849-L852. All of the options I've added belong in that `RavenConfig.config` sub-object. 

As discussed, this implementation is completely deferent to the existing `window.RavenConfig`, copying over any properties from the UI-entered settings **only** when they're `undefined` on the existing `window.RavenConfig.config`. The reasoning here was that since we don't have a rule engine for when to apply settings (they're blanketed across your whole project), that we should totally respect the RavenConfig variable as the user's page-specific "escape hatch" settings-wise. 

Where I still need a hand / extra-careful review:
- [ ] is allowing customers to pass their regexps as strings sane? is this the right approach for letting them do so? 

Obviously, status is **DO NOT MERGE** until we update metadata accordingly. 

@ndhoule @f2prateek 
