### PR TITLE
Support more options for Sentry

### DIFF
--- a/component.json
+++ b/component.json
@@ -7,7 +7,8 @@
   "main": "lib/index.js",
   "dependencies": {
     "segmentio/analytics.js-integration": "^1.0.1",
-    "ianstormtaylor/is": "0.1.0"
+    "ianstormtaylor/is": "0.1.0",
+    "ndhoule/defaults": "1.1.1"
   },
   "development": {
     "segmentio/analytics.js-core": "^2.10.0",

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@
  */
 
 var integration = require('analytics.js-integration');
+var defaults = require('defaults');
 var is = require('is');
 
 /**
@@ -14,6 +15,10 @@ var Sentry = module.exports = integration('Sentry')
   .global('Raven')
   .global('RavenConfig')
   .option('config', '')
+  .option('ignoreErrors', [])
+  .option('ignoreUrls', [])
+  .option('maxMessageLength', 100)
+  .option('logger', 'javascript')
   .tag('<script src="//cdn.ravenjs.com/1.1.16/native/raven.min.js">');
 
 /**
@@ -26,8 +31,24 @@ var Sentry = module.exports = integration('Sentry')
  */
 
 Sentry.prototype.initialize = function() {
+  var ignoreErrors = this.options.ignoreErrors;
+  var ignoreUrls = this.options.ignoreUrls;
+  var maxMessageLength = this.options.maxMessageLength;
+  var logger = this.options.logger;
+
   var dsn = this.options.config;
-  window.RavenConfig = { dsn: dsn };
+  var config = {};
+
+  if (ignoreErrors.length) config.ignoreErrors = ignoreErrors;
+  if (ignoreUrls.length) config.ignoreUrls = ignoreUrls;
+  if (maxMessageLength) config.maxMessageLength = maxMessageLength;
+  if (logger) config.logger = logger;
+
+  window.RavenConfig = defaults.deep(window.RavenConfig || {}, {
+    config: config,
+    dsn: dsn
+  });
+
   this.load(this.ready);
 };
 


### PR DESCRIPTION
This PR makes 2 changes:
1. Dont clobber existing settings unless it is set in our UI.
   This ensures that settings we don't support, such as the
   error callback function and regex matchers, are still
   respected.
2. Add native support for `maxMessageLength`, `logger`,
   `ignoreErrors` and `ignoreUrls`. Only strings are supported
   (wherever relevant) — users should use regexes in their own code if
   they need to.
