### PR TITLE
raven.js 1.3.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,13 +19,13 @@ var Sentry = module.exports = integration('Sentry')
   .option('ignoreUrls', [])
   .option('maxMessageLength', 100)
   .option('logger', 'javascript')
-  .tag('<script src="https://cdn.ravenjs.com/1.2.0/native/raven.min.js">');
+  .tag('<script src="https://cdn.ravenjs.com/1.3.0/native/raven.min.js">');
 
 /**
  * Initialize.
  *
  * https://docs.getsentry.com/hosted/clients/javascript/config/
- * https://github.com/getsentry/raven-js/blob/1.2.0/src/raven.js#L926-L932
+ * https://github.com/getsentry/raven-js/blob/1.3.0/src/raven.js#L942-L948
  *
  * @api public
  */


### PR DESCRIPTION
Again, I'm going to ask.. is there a better way that this can be automated to be kept up to date instead of me manually creating pull requests every time we bump a version?

Can this be specified possibly as a config option in Segment so people can say, "I want version 1.2.0", and maybe default to our latest version? We're thinking about exposing an API endpoint that has this information, but not sure if that could be leveraged for you guys.
