### PR TITLE
strip empty strings and modify empty array logic

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,13 +80,20 @@ Sentry.prototype.identify = function(identify) {
 
 function reject(obj) {
   return foldl(function(result, val, key) {
-    // strip any null values
-    if (val != null && !is.array(val)) {
+    // strip any null or empty string values
+    if (val !== null && val !== '' && !is.array(val)) {
       result[key] = val;
     }
     // strip any empty arrays
-    if (is.array(val) && !is.empty(val)) {
-      result[key] = val;
+    if (is.array(val)) {
+      var ret = [];
+      // strip if there's only an empty string or null in the array since the settings UI lets you save additional rows even though some may be empty strings
+      for (var x = 0; x < val.length; x++){
+        if (val[x] !== null && val[x] !== '') ret.push(val[x]);
+      }
+      if (!is.empty(ret)) {
+        result[key] = ret;
+      }
     }
     return result;
   }, {}, obj);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -85,10 +85,28 @@ describe('Sentry', function() {
         analytics.assert(!window.RavenConfig.config.release);
       });
 
+      it('should reject empty strings', function() {
+        sentry.options.release = '';
+        analytics.initialize();
+        analytics.assert(!window.RavenConfig.config.release);
+      });
+
       it('should reject empty array settings', function() {
         sentry.options.ignoreUrls = [];
         analytics.initialize();
         analytics.assert(!window.RavenConfig.config.ignoreUrls);
+      });
+
+      it('should reject arrays that have empty strings', function() {
+        sentry.options.ignoreUrls = [''];
+        analytics.initialize();
+        analytics.assert(!window.RavenConfig.config.ignoreUrls);
+      });
+
+      it('should clean arrays', function() {
+        sentry.options.ignoreUrls = ['', 'foo'];
+        analytics.initialize();
+        analytics.assert(window.RavenConfig.config.ignoreUrls[0] === 'foo');
       });
     });
   });


### PR DESCRIPTION
@WesleyDRobinson This should remove any empty strings, arrays that have empty strings that are set for the options.

I think the issue where these new settings were being set as empty strings was because you need to run a migration when you add new metadata settings @f2prateek 
