### PR TITLE
Use raven-js@3.24.2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@ var Sentry = module.exports = integration('Sentry')
   .option('maxMessageLength', null)
   .option('logger', null)
   .option('customVersionProperty', null)
-  .tag('<script src="https://cdn.ravenjs.com/3.17.0/raven.min.js" crossorigin="anonymous">');
+  .tag('<script src="https://cdn.ravenjs.com/3.24.1/raven.min.js" crossorigin="anonymous">');
 
 /**
  * Initialize.

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@ var Sentry = module.exports = integration('Sentry')
   .option('maxMessageLength', null)
   .option('logger', null)
   .option('customVersionProperty', null)
-  .tag('<script src="https://cdn.ravenjs.com/3.24.1/raven.min.js" crossorigin="anonymous">');
+  .tag('<script src="https://cdn.ravenjs.com/3.24.2/raven.min.js" crossorigin="anonymous">');
 
 /**
  * Initialize.


### PR DESCRIPTION
This PR was made mainly to take advantage of getsentry/raven-js#1253 when parsing non-Error like Objects that is a big improvement for errors debugging in Sentry.