### PR TITLE
Update sentry version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@ var Sentry = module.exports = integration('Sentry')
   .option('maxMessageLength', null)
   .option('logger', null)
   .option('customVersionProperty', null)
-  .tag('<script src="https://cdn.ravenjs.com/3.17.0/raven.min.js" crossorigin="anonymous">');
+  .tag('<script src="https://cdn.ravenjs.com/3.26.4/raven.min.js" crossorigin="anonymous">');
 
 /**
  * Initialize.


### PR DESCRIPTION
Using an outdated version of sentry and a customer (https://segment.zendesk.com/agent/tickets/170753) requested we update it.

According to sentry docs (https://docs.sentry.io/clients/javascript/), we are updating from 3.17.0 to 3.26.4.